### PR TITLE
re-add missing deps for arm64 build

### DIFF
--- a/chi-openstack/Dockerfile
+++ b/chi-openstack/Dockerfile
@@ -9,9 +9,9 @@ ARG openstack_release=train
 
 RUN dnf group install -y "Development Tools" \
   && dnf install -y \
-  libffi-devel \
-  libxml2-devel \
-  libxslt-devel \
+  libffi-devel `#needed for cffi on arm64, rdepend for paramiko and cryptography` \
+  libxml2-devel `#needed for lxml on arm64, rdepend for python-dracclient->python-chi-operator` \
+  libxslt-devel `#needed for lxml on arm64, rdepend for python-dracclient->python-chi-operator` \
   openssl-devel \
   python3-devel
 


### PR DESCRIPTION
on arm64, libffi-devel , libxml2-devel , and libxslt-devel need to be specified explicitly for build to succeed.