### PR TITLE
build arm64 and x86_64 for single tag

### DIFF
--- a/bin/chi
+++ b/bin/chi
@@ -121,4 +121,4 @@ if [[ -z "${1:-}" ]]; then
   cmd="bash"
 fi
 
-exec docker run "${docker_options[@]}" "$registry/chi-openstack-$(arch)" "${cmd:-$@}"
+exec docker run "${docker_options[@]}" "$registry/chi-openstack:latest" "${cmd:-$@}"


### PR DESCRIPTION
This builds and pushes using docker buildx, in order to build multiple platforms for one tag.

Users will need to manually run docker pull to get the new version if locally cached.